### PR TITLE
Skip the WSSO export when it is not configured

### DIFF
--- a/src/java/fr/paris/lutece/plugins/adminauthenticationwsso/service/WssoAdminUsersFileGeneratorService.java
+++ b/src/java/fr/paris/lutece/plugins/adminauthenticationwsso/service/WssoAdminUsersFileGeneratorService.java
@@ -81,6 +81,7 @@ public class WssoAdminUsersFileGeneratorService
     private static final String PROPERTY_XMLFILEFORMAT_ATTR_ALLOWED_USER_WSSO_GUID = "adminauthenticationwsso.wssofileformat.tag_wssoGUID";
     private static final String LOG_MESSAGE_OK = "\nWssoAdminUserFileGeneratorService : Update OK for file ";
     private static final String LOG_MESSAGE_NOK = "\nWssoAdminUserFileGeneratorService : Error when updating file ";
+    private static final String LOG_MESSAGE_NOT_CONFIGURED = "\nWssoAdminUserFileGeneratorService : export not configured, nothing done. Set adminauthenticationwsso.path and adminauthenticationwsso.fileName to enable it.";
     
     //Regex
     private static final String REGEX_WSSO_ID = AppPropertiesService.getProperty( "adminauthenticationwsso.wssoid.regex" );
@@ -162,6 +163,44 @@ public class WssoAdminUsersFileGeneratorService
     }
 
     /**
+     * Tells whether the WSSO export is configured, that is whether the location of the file to
+     * produce is known.
+     *
+     * <p>
+     * The properties file ships every value of this block empty, as a template :
+     * adminauthenticationwsso.path, .fileName, .appID and .appResponsable. On a site that never
+     * filled them in, AppPathService.getPath used to throw an AppException, so the daemon logged
+     * a stack trace on every run - hourly by default, since the plugin ships
+     * daemon.ExportWssoAdminUsersDaemon.interval=3600 and onstartup=1.
+     * </p>
+     *
+     * <p>
+     * Beware of what "empty" means here : since the v7 line of lutece-core resolves properties
+     * through MicroProfile Config, AppPropertiesService.getProperty returns null for a declared
+     * but empty value, not the empty string. Both cases have to be treated the same way.
+     * </p>
+     *
+     * @return true when the export can run
+     */
+    private static boolean isExportConfigured(  )
+    {
+        return !isBlank( AppPropertiesService.getProperty( PROPERTY_XML_STORAGE_FOLDER_PATH ) ) &&
+            !isBlank( AppPropertiesService.getProperty( PROPERTY_XML_FILE_NAME ) );
+    }
+
+    /**
+     * Tells whether a property value is absent or holds only whitespace.
+     *
+     * @param strValue
+     *            The value to test
+     * @return true when the value carries nothing usable
+     */
+    private static boolean isBlank( String strValue )
+    {
+        return ( strValue == null ) || strValue.trim(  ).isEmpty(  );
+    }
+
+    /**
      * Create or update the XML file with the getXml content
      *
      * @param plugin the plugin
@@ -172,6 +211,14 @@ public class WssoAdminUsersFileGeneratorService
 
         //String buffer for building the response page
         StringBuffer sbLogs = new StringBuffer(  );
+
+        if ( !isExportConfigured(  ) )
+        {
+            AppLogService.info( LOG_MESSAGE_NOT_CONFIGURED );
+
+            return LOG_MESSAGE_NOT_CONFIGURED;
+        }
+
         String strFileName = AppPropertiesService.getProperty( PROPERTY_XML_FILE_NAME );
         String strFolderPath = AppPathService.getPath( PROPERTY_XML_STORAGE_FOLDER_PATH, "" );
 
@@ -218,6 +265,11 @@ public class WssoAdminUsersFileGeneratorService
      */
     public static void removeXmlFile(  )
     {
+        if ( !isExportConfigured(  ) )
+        {
+            return;
+        }
+
         String strFileXml = AppPathService.getPath( PROPERTY_XML_STORAGE_FOLDER_PATH, "" ) +
             AppPropertiesService.getProperty( PROPERTY_XML_FILE_NAME );
         File file = new File( strFileXml );


### PR DESCRIPTION
### Le symptôme

Sur un site qui n'a jamais configuré l'export WSSO, `ExportWssoAdminUsersDaemon` échoue à **chaque** exécution, avec une trace complète :

```
ERROR - Critical AppException, root cause: AppException: Property
adminauthenticationwsso.path not found in the properties file
    at AppPathService.getPath(AppPathService.java:139)
    at WssoAdminUsersFileGeneratorService.createXmlFile(...:176)
    at AutoExportWssoAdminUsersFile.processExportXmlFile(...:64)
    at ExportWssoAdminUsersDaemon.run(...:62)
```

Le plugin livrant `interval=3600` et `onstartup=1`, cela se produit au démarrage puis toutes les heures, indéfiniment.

### Le message est trompeur : la propriété est déclarée

Ce plugin livre tout le bloc **vide**, en guise de gabarit — `adminauthenticationwsso.path`, `.fileName`, `.appID`, `.appResponsable`, ainsi que les noms de balises XML :

```properties
#Example :
#adminauthenticationwsso.path=/example
adminauthenticationwsso.appID=
adminauthenticationwsso.appResponsable=
adminauthenticationwsso.path=
adminauthenticationwsso.fileName=
```

Ce qui a changé, c'est **le sens d'une valeur vide**. La ligne v7 de lutece-core résout désormais les propriétés par MicroProfile Config :

```java
public static String getProperty( String strProperty )
{
    return _config.getOptionalValue( strProperty, String.class ).orElse( null );
}
```

MicroProfile traite une valeur déclarée mais vide comme **absente** : `getProperty` rend `null` là où `Properties.getProperty` rendait `""`. Et `AppPathService.getPath` ne teste que la nullité :

```java
String strDirectory = AppPropertiesService.getProperty( strKey );
if ( strDirectory == null )
{
    throw new AppException( ... "not found in the properties file" );
}
```

D'où l'exception sur une propriété qui est simplement vide. C'est un changement de sémantique qui touche potentiellement tout plugin livrant des propriétés vides comme gabarit — cette pratique est courante.

### Le correctif

`createXmlFile` sort maintenant immédiatement lorsque l'emplacement du fichier à produire est inconnu, avec une ligne INFO nommant les propriétés à renseigner. `removeXmlFile` reçoit la même garde, puisqu'elle résout le même chemin.

Le test de vacuité couvre **les deux cas** — `null` et chaîne vide — précisément parce que la sémantique diffère selon la ligne du core. Il est écrit localement plutôt qu'avec `StringUtils`, ce pom ne déclarant pas commons-lang.

Un site configuré se comporte exactement comme avant : rien d'autre ne change.

### Pourquoi corriger ici plutôt que désactiver le daemon site par site

Le contournement immédiat existe — poser `daemon.ExportWssoAdminUsersDaemon.onstartup=0` dans la surcharge du site. Mais il faudrait le faire sur chaque site installant ce plugin sans utiliser l'export, et rien ne le signale : le symptôme est une trace dans les logs, pas une panne visible. **Une fonctionnalité optionnelle non configurée doit rester silencieuse.**

### Vérifications

`mvn clean install` en JDK 11 : `BUILD SUCCESS`. Diff de **52 insertions, aucune suppression** — les fins de ligne CRLF du fichier sont préservées.
